### PR TITLE
Refactor

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
-
 import 'helper/cart_helper.dart';
 import 'helper/favourite_helper.dart';
 import 'providers/category_provider.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
-import 'package:untitled1/providers/category_provider.dart';
-import 'package:untitled1/providers/product_provider.dart';
 
 import 'helper/cart_helper.dart';
 import 'helper/favourite_helper.dart';
+import 'providers/category_provider.dart';
+import 'providers/product_provider.dart';
 import 'screens/splash_screen/splash_screen.dart';
 import 'utils/constants.dart';
 

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -1,7 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:online_shop/utils/constants.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:untitled1/utils/constants.dart';
 
 import '../screens/main_screen.dart';
 

--- a/lib/screens/auth/forget_password_screen.dart
+++ b/lib/screens/auth/forget_password_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:untitled1/utils/constants.dart';
+import 'package:online_shop/utils/constants.dart';
 
 import '../../widgets/auth/custom_button.dart';
 import '../../widgets/auth/custom_textField.dart';

--- a/lib/screens/cart/cart_screen.dart
+++ b/lib/screens/cart/cart_screen.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:online_shop/providers/product_provider.dart';
+import 'package:online_shop/screens/payment/payment_screen.dart';
 import 'package:provider/provider.dart';
-import 'package:untitled1/providers/product_provider.dart';
-import 'package:untitled1/screens/payment/payment_screen.dart';
-import 'package:untitled1/widgets/product_card.dart';
 
 import '../../helper/cart_helper.dart';
 import '../../utils/constants.dart';
 import '../../widgets/auth/custom_button.dart';
 import '../../widgets/empty_massege.dart';
+import '../../widgets/product_card.dart';
 
 class CartScreen extends StatelessWidget {
   const CartScreen({super.key});

--- a/lib/screens/details/detail_screen.dart
+++ b/lib/screens/details/detail_screen.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:online_shop/models/product_model.dart';
+import 'package:online_shop/utils/constants.dart';
 import 'package:provider/provider.dart';
 import 'package:rate/rate.dart';
-import 'package:untitled1/models/product_model.dart';
-import 'package:untitled1/utils/constants.dart';
-
 import '../../helper/cart_helper.dart';
 import '../../helper/favourite_helper.dart';
 import '../../widgets/auth/custom_button.dart';

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:untitled1/screens/profile/profile_screen.dart';
+import 'package:online_shop/screens/profile/profile_screen.dart';
 
 import '../widgets/bottom_nav_bar.dart';
 import '../widgets/home/app_bar_widget.dart';

--- a/lib/screens/onboarding/onboarding_screen.dart
+++ b/lib/screens/onboarding/onboarding_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:online_shop/screens/auth/login_screen.dart';
+import 'package:online_shop/screens/auth/sign_up_screen.dart';
 import 'package:provider/provider.dart';
-import 'package:untitled1/screens/auth/login_screen.dart';
-import 'package:untitled1/screens/auth/sign_up_screen.dart';
 
 import '../../providers/onboarding_provider.dart';
 import '../../widgets/auth/custom_button.dart';

--- a/lib/widgets/auth/login/login_footer.dart
+++ b/lib/widgets/auth/login/login_footer.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:untitled1/widgets/auth/social_button.dart';
+
+import '../social_button.dart';
+
 
 class LoginFooter extends StatelessWidget {
   const LoginFooter({super.key});

--- a/lib/widgets/auth/login/login_form.dart
+++ b/lib/widgets/auth/login/login_form.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:online_shop/utils/constants.dart';
 import 'package:provider/provider.dart';
-import 'package:untitled1/screens/auth/forget_password_screen.dart';
-import 'package:untitled1/utils/constants.dart';
-import 'package:untitled1/widgets/auth/custom_button.dart';
-import 'package:untitled1/widgets/auth/custom_textField.dart';
 
 import '../../../providers/auth_provider.dart';
+import '../../../screens/auth/forget_password_screen.dart';
+import '../custom_button.dart';
+import '../custom_textField.dart';
 
 class LoginForm extends StatelessWidget {
   const LoginForm({super.key});

--- a/lib/widgets/auth/login/login_header.dart
+++ b/lib/widgets/auth/login/login_header.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:untitled1/widgets/auth/registration_label.dart';
 
 import '../../../screens/auth/sign_up_screen.dart';
+import '../registration_label.dart';
 
 class LoginHeader extends StatelessWidget {
   const LoginHeader({super.key});

--- a/lib/widgets/auth/signup/signup_footer.dart
+++ b/lib/widgets/auth/signup/signup_footer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:untitled1/widgets/auth/social_button.dart';
+
+import '../social_button.dart';
 
 class SignupFooter extends StatelessWidget {
   const SignupFooter({super.key});

--- a/lib/widgets/auth/signup/signup_form.dart
+++ b/lib/widgets/auth/signup/signup_form.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:online_shop/utils/constants.dart';
+import 'package:online_shop/widgets/auth/custom_button.dart';
+import 'package:online_shop/widgets/auth/custom_textField.dart';
 import 'package:provider/provider.dart';
-import 'package:untitled1/utils/constants.dart';
-import 'package:untitled1/widgets/auth/custom_button.dart';
-import 'package:untitled1/widgets/auth/custom_textField.dart';
 
 import '../../../providers/auth_provider.dart';
 import '../../../screens/auth/confirmed_page.dart';

--- a/lib/widgets/auth/signup/signup_header.dart
+++ b/lib/widgets/auth/signup/signup_header.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:untitled1/widgets/auth/registration_label.dart';
+import 'package:online_shop/widgets/auth/registration_label.dart';
 
 import '../../../screens/auth/login_screen.dart';
 

--- a/lib/widgets/auth/social_button.dart
+++ b/lib/widgets/auth/social_button.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:untitled1/utils/constants.dart';
-
+import 'package:online_shop/utils/constants.dart';
 class SocialButtons extends StatelessWidget {
   const SocialButtons({super.key});
 

--- a/lib/widgets/detail/app_bar.dart
+++ b/lib/widgets/detail/app_bar.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:untitled1/utils/constants.dart';
 
 import '../../helper/cart_helper.dart';
 import '../../screens/cart/cart_screen.dart';
+import '../../utils/constants.dart';
 
 class AppBarWidget extends StatelessWidget implements PreferredSizeWidget {
   const AppBarWidget({super.key, required this.title});

--- a/lib/widgets/home/app_bar_widget.dart
+++ b/lib/widgets/home/app_bar_widget.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:online_shop/screens/cart/cart_screen.dart';
 import 'package:provider/provider.dart';
-import 'package:untitled1/screens/cart/cart_screen.dart';
-
 import '../../helper/cart_helper.dart';
 import '../../utils/constants.dart';
 

--- a/lib/widgets/home/product_grid_view.dart
+++ b/lib/widgets/home/product_grid_view.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:online_shop/providers/product_provider.dart';
 import 'package:provider/provider.dart';
-import 'package:untitled1/providers/product_provider.dart';
-
 import 'product_item.dart';
 
 class ProductGridView extends StatelessWidget {

--- a/lib/widgets/home/section_header.dart
+++ b/lib/widgets/home/section_header.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:untitled1/utils/constants.dart';
 
+import '../../utils/constants.dart';
 class SectionHeader extends StatelessWidget {
   final String title;
 

--- a/lib/widgets/product_card.dart
+++ b/lib/widgets/product_card.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:online_shop/utils/constants.dart';
 import 'package:provider/provider.dart';
-import 'package:untitled1/utils/constants.dart';
-
 import '../../models/product_model.dart';
 import '../helper/cart_helper.dart';
 import '../screens/details/detail_screen.dart';

--- a/lib/widgets/profile/profile_options.dart
+++ b/lib/widgets/profile/profile_options.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:untitled1/screens/onboarding/onboarding_screen.dart';
+import 'package:online_shop/screens/onboarding/onboarding_screen.dart';
 
 import 'expansion_tile.dart';
 import 'profile_option.dart';

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:untitled1/main.dart';
+
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {


### PR DESCRIPTION
This pull request involves updating import paths throughout the codebase to reflect the new package name `online_shop` instead of `untitled1`. This change aims to improve code clarity and maintainability by using a more descriptive package name.

Key changes include:

### Import Path Updates

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L5-R8): Updated import paths for `category_provider.dart` and `product_provider.dart` to reflect the new package name.
* [`lib/providers/auth_provider.dart`](diffhunk://#diff-25b840ea49539216dbff908574e6985b56cbcab370b6ae7bec77db9504822b54R3-L4): Changed the import path for `constants.dart` to use `online_shop` package name.
* [`lib/screens/auth/forget_password_screen.dart`](diffhunk://#diff-83411e0708895a100130b8ce10e8cfc2d0a06739f92c45803485c08707bd8362L2-R2): Updated the import path for `constants.dart` to use `online_shop` package name.
* [`lib/screens/cart/cart_screen.dart`](diffhunk://#diff-c269b98175164675d40de8ff2becacd116b0be4d87f6abb2f94553f0a09198e0R2-R10): Modified import paths for `product_provider.dart`, `payment_screen.dart`, and `product_card.dart` to use `online_shop` package name.
* [`lib/screens/details/detail_screen.dart`](diffhunk://#diff-c24f81cf8983cbb3428e731c8375bb0ba081d22dab496e6bdca0ff205673f8caR2-L6): Updated import paths for `product_model.dart` and `constants.dart` to use `online_shop` package name.

These changes ensure that all relevant files now reference the `online_shop` package, enhancing the readability and organization of the project.